### PR TITLE
Fix timeout issue

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -7,15 +7,9 @@ import (
 )
 
 var (
-	timeout  = make(chan bool, 1)
 	gcChan   = make(chan *gctrace, 1)
 	scvgChan = make(chan *scvgtrace, 1)
 )
-
-func timeoutAfter(d time.Duration, t *testing.T) {
-	time.Sleep(d)
-	timeout <- true
-}
 
 func runParserWith(line string) {
 	reader := bytes.NewReader([]byte(line))
@@ -30,8 +24,6 @@ func runParserWith(line string) {
 }
 
 func TestParserWithMatchingInput(t *testing.T) {
-	go timeoutAfter(100*time.Millisecond, t)
-
 	line := "gc76(1): 2+1+1390+1 us, 1 -> 3 MB, 16397 (1015746-999349) objects, 1436/1/0 sweeps, 0(0) handoff, 0(0) steal, 0/0/0 yields\n"
 
 	go runParserWith(line)
@@ -43,14 +35,13 @@ func TestParserWithMatchingInput(t *testing.T) {
 		if gctrace.Heap1 != expectedHeapSize {
 			t.Errorf("Expected gctrace.Heap1 to equal %d. Got %d instead.", expectedHeapSize, gctrace.Heap1)
 		}
-	case <-timeout:
+	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Execution timed out.")
 	}
 }
 
 func TestParserGoRoutinesInput(t *testing.T) {
 	t.Skip()
-	go timeoutAfter(100*time.Millisecond, t)
 
 	line := "gc76(1): 2+1+1390+1 us, 1 -> 3 MB, 16397 (1015746-999349) objects, 12 goroutines, 1436/1/0 sweeps, 0(0) handoff, 0(0) steal, 0/0/0 yields\n"
 
@@ -63,14 +54,12 @@ func TestParserGoRoutinesInput(t *testing.T) {
 		if gctrace.Heap1 != expectedHeapSize {
 			t.Errorf("Expected gctrace.Heap1 to equal %d. Got %d instead.", expectedHeapSize, gctrace.Heap1)
 		}
-	case <-timeout:
+	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Execution timed out.")
 	}
 }
 
 func TestParserNonMatchingInput(t *testing.T) {
-	go timeoutAfter(100*time.Millisecond, t)
-
 	line := "INFO: test"
 	ended := make(chan bool, 1)
 
@@ -86,7 +75,7 @@ func TestParserNonMatchingInput(t *testing.T) {
 		t.Fatalf("Unexpected trace result. This input should not trigger scvgChan.")
 	case <-ended:
 		return
-	case <-timeout:
+	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("Execution timed out.")
 	}
 }


### PR DESCRIPTION
`timeoutAfter` would make other tests cases fail if they took more than
the duration passed in parameter. Each test now creates its own timeout
channel, avoiding shared state between tests.

@davecheney You told me to add the timeout in `runParserWith` but I feel that placing it in timeoutAfter makes more sense.