### PR TITLE
Use regexp to match stdout instead of fmt.Sscanf

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-type graphPoints [2]int
+type graphPoints [2]int64
 
 type Graph struct {
 	Title                                                             string
@@ -44,14 +44,14 @@ func (g *Graph) write(w io.Writer) {
 func (g *Graph) AddGCTraceGraphPoint(gcTrace *gctrace) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	ts := int(time.Now().UnixNano() / 1e6)
+	ts := int64(time.Now().UnixNano() / 1e6)
 	g.HeapUse = append(g.HeapUse, graphPoints{ts, gcTrace.Heap1})
 }
 
 func (g *Graph) AddScavengerGraphPoint(scvg *scvgtrace) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	ts := int(time.Now().UnixNano() / 1e6)
+	ts := int64(time.Now().UnixNano() / 1e6)
 	g.ScvgInuse = append(g.ScvgInuse, graphPoints{ts, scvg.inuse})
 	g.ScvgIdle = append(g.ScvgIdle, graphPoints{ts, scvg.idle})
 	g.ScvgSys = append(g.ScvgSys, graphPoints{ts, scvg.sys})

--- a/parser.go
+++ b/parser.go
@@ -6,13 +6,12 @@ import (
 	"io"
 	"log"
 	"regexp"
+	"strconv"
 )
 
 const (
-	GCRegexp      = `gc\d+\(\d+\): \d+\+\d+\+\d+\+\d+ us, \d+ -> \d+ MB, \d+ \(\d+-\d+\) objects, \d+\/\d+\/\d+ sweeps, \d+\(\d+\) handoff, \d+\(\d+\) steal, \d+\/\d+\/\d+ yields`
-	SCVGRegexp    = `scvg\d+: inuse: \d+, idle: \d+, sys: \d+, released: \d+, consumed: \d+ \(MB\)`
-	GCTraceScan   = "gc%d(%d): %d+%d+%d+%d us, %d -> %d MB, %d (%d-%d) objects, %d/%d/%d sweeps, %d(%d) handoff, %d(%d) steal, %d/%d/%d yields\n"
-	SCVGTraceScan = "scvg%d: inuse: %d, idle: %d, sys: %d, released: %d, consumed: %d (MB)\n"
+	GCRegexp   = `gc\d+\(\d+\): \d+\+\d+\+\d+\+\d+ us, \d+ -> (?P<Heap1>\d+) MB, \d+ \(\d+-\d+\) objects,( \d+ goroutines,)? \d+\/\d+\/\d+ sweeps, \d+\(\d+\) handoff, \d+\(\d+\) steal, \d+\/\d+\/\d+ yields`
+	SCVGRegexp = `scvg\d+: inuse: (?P<inuse>\d+), idle: (?P<idle>\d+), sys: (?P<sys>\d+), released: (?P<released>\d+), consumed: (?P<consumed>\d+) \(MB\)`
 )
 
 var (
@@ -31,22 +30,17 @@ func (p *Parser) Run() {
 
 	for sc.Scan() {
 		line := sc.Text()
-		// try to parse as a gc trace line
-		if gcre.MatchString(line) {
-			if gcTrace := parseGCTrace(line); gcTrace != nil {
-				p.gcChan <- gcTrace
-			}
+
+		if result := gcre.FindStringSubmatch(line); result != nil {
+			p.gcChan <- parseGCTrace(result)
 			continue
 		}
 
-		if scvgre.MatchString(line) {
-			if scvgTrace := parseSCVGTrace(line); scvgTrace != nil {
-				p.scvgChan <- scvgTrace
-			}
+		if result := scvgre.FindStringSubmatch(line); result != nil {
+			p.scvgChan <- parseSCVGTrace(result)
 			continue
 		}
 
-		// nope ? oh well, print it out
 		fmt.Println(line)
 	}
 
@@ -55,31 +49,43 @@ func (p *Parser) Run() {
 	}
 }
 
-func parseGCTrace(line string) *gctrace {
-	var gc gctrace
+func parseGCTrace(matches []string) *gctrace {
+	matchMap := getMatchMap(gcre, matches)
 
-	_, err := fmt.Sscanf(
-		line, GCTraceScan,
-		&gc.NumGC, &gc.Nproc, &gc.t1, &gc.t2, &gc.t3, &gc.t4, &gc.Heap0, &gc.Heap1, &gc.Obj, &gc.NMalloc, &gc.NFree,
-		&gc.NSpan, &gc.NBGSweep, &gc.NPauseSweep, &gc.NHandoff, &gc.NHandoffCnt, &gc.NSteal, &gc.NStealCnt, &gc.NProcYield, &gc.NOsYield, &gc.NSleep,
-	)
-
-	if err != nil {
-		log.Printf("corrupt gctrace: %v: %s", err, line)
-		return nil
+	return &gctrace{
+		Heap1: matchMap["Heap1"],
 	}
-
-	return &gc
 }
 
-func parseSCVGTrace(line string) *scvgtrace {
-	var scvg scvgtrace
-	var n int
-	_, err := fmt.Sscanf(line, SCVGTraceScan,
-		&n, &scvg.inuse, &scvg.idle, &scvg.sys, &scvg.released, &scvg.consumed)
-	if err != nil {
-		log.Printf("corrupt scvgtrace: %v: %s", err, line)
-		return nil
+func parseSCVGTrace(matches []string) *scvgtrace {
+	matchMap := getMatchMap(scvgre, matches)
+
+	return &scvgtrace{
+		inuse:    matchMap["inuse"],
+		idle:     matchMap["idle"],
+		sys:      matchMap["sys"],
+		released: matchMap["released"],
+		consumed: matchMap["consumed"],
 	}
-	return &scvg
+}
+
+// Transform our matches in a readable hash map.
+//
+// The resulting hash map will be something like { "Heap1": 123 }
+func getMatchMap(re *regexp.Regexp, matches []string) map[string]int64 {
+	matchingNames := re.SubexpNames()
+	matchMap := map[string]int64{}
+	for i, value := range matches {
+		intVal, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			// Happens on first element of range and any matching parenthesis
+			// that includes non-parseable string
+			//
+			// For example a matching array would contain:
+			// [ "scvg1: inuse:3 ..." "3" ]
+			continue
+		}
+		matchMap[matchingNames[i]] = intVal
+	}
+	return matchMap
 }

--- a/tracedata.go
+++ b/tracedata.go
@@ -1,34 +1,34 @@
 package main
 
 type scvgtrace struct {
-	inuse    int
-	idle     int
-	sys      int
-	released int
-	consumed int
+	inuse    int64
+	idle     int64
+	sys      int64
+	released int64
+	consumed int64
 }
 
 type gctrace struct {
-	NumGC       int
-	Nproc       int
-	t1          int
-	t2          int
-	t3          int
-	t4          int
-	Heap0       int // heap size before, in megabytes
-	Heap1       int // heap size after, in megabytes
-	Obj         int
-	NMalloc     int
-	NFree       int
-	NSpan       int
-	NGoRoutines int
-	NBGSweep    int
-	NPauseSweep int
-	NHandoff    int
-	NHandoffCnt int
-	NSteal      int
-	NStealCnt   int
-	NProcYield  int
-	NOsYield    int
-	NSleep      int
+	NumGC       int64
+	Nproc       int64
+	t1          int64
+	t2          int64
+	t3          int64
+	t4          int64
+	Heap0       int64 // heap size before, in megabytes
+	Heap1       int64 // heap size after, in megabytes
+	Obj         int64
+	NMalloc     int64
+	NFree       int64
+	NSpan       int64
+	NGoRoutines int64
+	NBGSweep    int64
+	NPauseSweep int64
+	NHandoff    int64
+	NHandoffCnt int64
+	NSteal      int64
+	NStealCnt   int64
+	NProcYield  int64
+	NOsYield    int64
+	NSleep      int64
 }


### PR DESCRIPTION
This allows us to match on goroutines conditionally and still support go
versions inferior to 1.4.

If you could review/merge this one, then I could rebase my other PR on top of master to fix the timeout issue everywhere.

Cheers.