### PR TITLE
Fix template import

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"html/template"
 	"io"
 	"sync"
-	"text/template"
 	"time"
 )
 


### PR DESCRIPTION
The javascript is currently broken.

This one is on me :disappointed:. When I refactored I was still running the old `gcvis` executable in my `GOPATH`. Turns out goimports added this dependency thinking it was a `text/template` when in fact we used `html/template` before.

Sorry about that. I wish I could have a bit of time to add tests around the http server but that'll have to wait a bit.