### PR TITLE
Strip gcvis flags from the subprocess arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	gcvisGraph = NewGraph(strings.Join(flag.Args(), " "), GCVIS_TMPL)
 
-	go startSubprocess(pw)
+	go startSubprocess(pw, flag.Args())
 	go parser.Run()
 
 	http.HandleFunc("/", indexHandler)

--- a/subprocess.go
+++ b/subprocess.go
@@ -7,9 +7,8 @@ import (
 	"os/exec"
 )
 
-func startSubprocess(w io.Writer) {
+func startSubprocess(w io.Writer, args []string) {
 	env := append(os.Environ(), "GODEBUG=gctrace=1")
-	args := os.Args[1:]
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = env
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
Unless this is done gcvis tries to execute '-i=...' as the command
when setting the address on which to listen.