### PR TITLE
Add timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Visualise Go program gctrace data in real time
 
+Note: GC timing graphs are only supported for go 1.6
+
 ## Usage
 
 Running it directly:

--- a/graph.go
+++ b/graph.go
@@ -13,6 +13,14 @@ type Graph struct {
 	Title                               string
 	HeapUse, ScvgInuse, ScvgIdle        []graphPoints
 	ScvgSys, ScvgReleased, ScvgConsumed []graphPoints
+	STWSclock                           []graphPoints
+	MASclock                            []graphPoints
+	STWMclock                           []graphPoints
+	STWScpu                             []graphPoints
+	MASAssistcpu                        []graphPoints
+	MASBGcpu                            []graphPoints
+	MASIdlecpu                          []graphPoints
+	STWMcpu                             []graphPoints
 	Tmpl                                *template.Template `json:"-"`
 	mu                                  sync.RWMutex       `json:"-"`
 }
@@ -28,6 +36,14 @@ func NewGraph(title, tmpl string) Graph {
 		ScvgSys:      []graphPoints{},
 		ScvgReleased: []graphPoints{},
 		ScvgConsumed: []graphPoints{},
+		STWSclock:    []graphPoints{},
+		MASclock:     []graphPoints{},
+		STWMclock:    []graphPoints{},
+		STWScpu:      []graphPoints{},
+		MASAssistcpu: []graphPoints{},
+		MASBGcpu:     []graphPoints{},
+		MASIdlecpu:   []graphPoints{},
+		STWMcpu:      []graphPoints{},
 	}
 	g.setTmpl(tmpl)
 
@@ -54,6 +70,14 @@ func (g *Graph) AddGCTraceGraphPoint(gcTrace *gctrace) {
 		elapsedTime = gcTrace.ElapsedTime
 	}
 	g.HeapUse = append(g.HeapUse, graphPoints{elapsedTime, float64(gcTrace.Heap1)})
+	g.STWSclock = append(g.STWSclock, graphPoints{elapsedTime, float64(gcTrace.STWSclock)})
+	g.MASclock = append(g.MASclock, graphPoints{elapsedTime, float64(gcTrace.MASclock)})
+	g.STWMclock = append(g.STWMclock, graphPoints{elapsedTime, float64(gcTrace.STWMclock)})
+	g.STWScpu = append(g.STWScpu, graphPoints{elapsedTime, float64(gcTrace.STWScpu)})
+	g.MASAssistcpu = append(g.MASAssistcpu, graphPoints{elapsedTime, float64(gcTrace.MASAssistcpu)})
+	g.MASBGcpu = append(g.MASBGcpu, graphPoints{elapsedTime, float64(gcTrace.MASBGcpu)})
+	g.MASIdlecpu = append(g.MASIdlecpu, graphPoints{elapsedTime, float64(gcTrace.MASIdlecpu)})
+	g.STWMcpu = append(g.STWMcpu, graphPoints{elapsedTime, float64(gcTrace.STWMcpu)})
 }
 
 func (g *Graph) AddScavengerGraphPoint(scvg *scvgtrace) {

--- a/parser.go
+++ b/parser.go
@@ -9,8 +9,9 @@ import (
 
 const (
 	GCRegexpGo14 = `gc\d+\(\d+\): ([\d.]+\+?)+ us, \d+ -> (?P<Heap1>\d+) MB, \d+ \(\d+-\d+\) objects,( \d+ goroutines,)? \d+\/\d+\/\d+ sweeps, \d+\(\d+\) handoff, \d+\(\d+\) steal, \d+\/\d+\/\d+ yields`
-	GCRegexpGo15 = `gc #?\d+ @(?P<ElapsedTime>[\d.]+)s \d+%: [\d.+/]+ ms clock, [\d.+/]+ ms cpu, \d+->\d+->\d+ MB, (?P<Heap1>\d+) MB goal, \d+ P`
-	SCVGRegexp   = `scvg\d+: inuse: (?P<inuse>\d+), idle: (?P<idle>\d+), sys: (?P<sys>\d+), released: (?P<released>\d+), consumed: (?P<consumed>\d+) \(MB\)`
+	GCRegexpGo15 = `gc #?\d+ @(?P<ElapsedTime>[\d.]+)s \d+%: (?P<STWSclock>[^+]+)\+(?P<MASclock>[^+]+)\+(?P<STWMclock>[^+]+) ms clock, (?P<STWScpu>[^+]+)\+(?P<MASAssistcpu>[^+]+)/(?P<MASBGcpu>[^+]+)/(?P<MASIdlecpu>[^+]+)\+(?P<STWMcpu>[^+]+) ms cpu, \d+->\d+->\d+ MB, (?P<Heap1>\d+) MB goal, \d+ P`
+
+	SCVGRegexp = `scvg\d+: inuse: (?P<inuse>\d+), idle: (?P<idle>\d+), sys: (?P<sys>\d+), released: (?P<released>\d+), consumed: (?P<consumed>\d+) \(MB\)`
 )
 
 var (
@@ -74,8 +75,16 @@ func parseGCTrace(gcre *regexp.Regexp, matches []string) *gctrace {
 	matchMap := getMatchMap(gcre, matches)
 
 	return &gctrace{
-		Heap1:       silentParseInt(matchMap["Heap1"]),
-		ElapsedTime: silentParseFloat(matchMap["ElapsedTime"]),
+		Heap1:        silentParseInt(matchMap["Heap1"]),
+		ElapsedTime:  silentParseFloat(matchMap["ElapsedTime"]),
+		STWSclock:    silentParseFloat(matchMap["STWSclock"]),
+		MASclock:     silentParseFloat(matchMap["MASclock"]),
+		STWMclock:    silentParseFloat(matchMap["STWMclock"]),
+		STWScpu:      silentParseFloat(matchMap["STWScpu"]),
+		MASAssistcpu: silentParseFloat(matchMap["MASAssistcpu"]),
+		MASBGcpu:     silentParseFloat(matchMap["MASBGcpu"]),
+		MASIdlecpu:   silentParseFloat(matchMap["MASIdlecpu"]),
+		STWMcpu:      silentParseFloat(matchMap["STWMcpu"]),
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -9,7 +9,8 @@ import (
 
 const (
 	GCRegexpGo14 = `gc\d+\(\d+\): ([\d.]+\+?)+ us, \d+ -> (?P<Heap1>\d+) MB, \d+ \(\d+-\d+\) objects,( \d+ goroutines,)? \d+\/\d+\/\d+ sweeps, \d+\(\d+\) handoff, \d+\(\d+\) steal, \d+\/\d+\/\d+ yields`
-	GCRegexpGo15 = `gc #?\d+ @(?P<ElapsedTime>[\d.]+)s \d+%: (?P<STWSclock>[^+]+)\+(?P<MASclock>[^+]+)\+(?P<STWMclock>[^+]+) ms clock, (?P<STWScpu>[^+]+)\+(?P<MASAssistcpu>[^+]+)/(?P<MASBGcpu>[^+]+)/(?P<MASIdlecpu>[^+]+)\+(?P<STWMcpu>[^+]+) ms cpu, \d+->\d+->\d+ MB, (?P<Heap1>\d+) MB goal, \d+ P`
+	GCRegexpGo15 = `gc #?\d+ @(?P<ElapsedTime>[\d.]+)s \d+%: [\d.+/]+ ms clock, [\d.+/]+ ms cpu, \d+->\d+->\d+ MB, (?P<Heap1>\d+) MB goal, \d+ P`
+	GCRegexpGo16 = `gc #?\d+ @(?P<ElapsedTime>[\d.]+)s \d+%: (?P<STWSclock>[^+]+)\+(?P<MASclock>[^+]+)\+(?P<STWMclock>[^+]+) ms clock, (?P<STWScpu>[^+]+)\+(?P<MASAssistcpu>[^+]+)/(?P<MASBGcpu>[^+]+)/(?P<MASIdlecpu>[^+]+)\+(?P<STWMcpu>[^+]+) ms cpu, \d+->\d+->\d+ MB, (?P<Heap1>\d+) MB goal, \d+ P`
 
 	SCVGRegexp = `scvg\d+: inuse: (?P<inuse>\d+), idle: (?P<idle>\d+), sys: (?P<sys>\d+), released: (?P<released>\d+), consumed: (?P<consumed>\d+) \(MB\)`
 )
@@ -17,6 +18,7 @@ const (
 var (
 	gcrego14 = regexp.MustCompile(GCRegexpGo14)
 	gcrego15 = regexp.MustCompile(GCRegexpGo15)
+	gcrego16 = regexp.MustCompile(GCRegexpGo16)
 	scvgre   = regexp.MustCompile(SCVGRegexp)
 )
 
@@ -47,6 +49,10 @@ func (p *Parser) Run() {
 
 	for sc.Scan() {
 		line := sc.Text()
+		if result := gcrego16.FindStringSubmatch(line); result != nil {
+			p.GcChan <- parseGCTrace(gcrego16, result)
+			continue
+		}
 
 		if result := gcrego15.FindStringSubmatch(line); result != nil {
 			p.GcChan <- parseGCTrace(gcrego15, result)

--- a/parser_test.go
+++ b/parser_test.go
@@ -17,13 +17,21 @@ func runParserWith(line string) *Parser {
 }
 
 func TestParserWithMatchingInputGo16(t *testing.T) {
-	line := "gc #88 @3.243s 9%: 0.040+16+1.0+5.9+0.34 ms clock, 0.16+16+0+18/5.7/11+1.3 ms cpu, 32->33->19 MB, 33 MB goal, 4 P"
+	line := "gc 763 @77536.239s 1%: 0.11+2192+0.75 ms clock, 0.92+9269/4379/3243+6.0 ms cpu, 6370->6390->3298 MB, 6533 MB goal, 8 P"
 
 	runParserWith(line)
 
 	expectedGCTrace := &gctrace{
-		Heap1:       33,
-		ElapsedTime: 3.243,
+		Heap1:        6533,
+		ElapsedTime:  77536.239,
+		STWSclock:    0.11,
+		MASclock:     2192,
+		STWMclock:    0.75,
+		STWScpu:      0.92,
+		MASAssistcpu: 9269,
+		MASBGcpu:     4379,
+		MASIdlecpu:   3243,
+		STWMcpu:      6.0,
 	}
 
 	select {

--- a/template.go
+++ b/template.go
@@ -8,11 +8,12 @@ const (
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.selection.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.stack.min.js"></script>
 
 <script type="text/javascript">
 
 (function() {
-	var data = [
+	var datagraph_data = [
 		{ label: "gc.heapinuse", data: {{ .HeapUse }} },
 		{ label: "scvg.inuse", data: {{ .ScvgInuse }} },
 		{ label: "scvg.idle", data: {{ .ScvgIdle }} },
@@ -21,7 +22,7 @@ const (
 		{ label: "scvg.consumed", data: {{ .ScvgConsumed }} }
 	];
 
-	var options = {
+	var datagraph_options = {
 		legend: {
 			position: "nw",
 			noColumns: 2,
@@ -38,10 +39,49 @@ const (
 		},
 	};
 
-	$(document).ready(function() {
-		var plot = $.plot("#placeholder", data, options);
+	var timingsgraph_data = [
+		{ label: "STW sweep clock", data: {{ .STWSclock }} },
+		{ label: "con mas clock", data: {{ .MASclock }} },
+		{ label: "STW mark clock", data: {{ .STWMclock }} },
+		{ label: "STW sweep cpu", data: {{ .STWScpu }} },
+		{ label: "con mas assist cpu", data: {{ .MASAssistcpu }} },
+		{ label: "con mas bg cpu", data: {{ .MASBGcpu }} },
+		{ label: "con mas idle cpu", data: {{ .MASIdlecpu }} },
+		{ label: "STW mark cpu", data: {{ .STWMcpu }} },
+	];
 
-		var overview = $.plot("#overview", data, {
+	var timingsgraph_options = {
+		legend: {
+			position: "nw",
+			noColumns: 2,
+			backgroundOpacity: 0.2
+		},
+		yaxis: {
+			tickFormatter: function(val) { return val + "ms"; }
+		},
+		xaxis: {
+			tickFormatter: function(val) { return val + "s"; }
+		},
+		selection: {
+			mode: "x"
+		},
+		series: {
+			stack: 0,
+			lines: {
+				show: false,
+			},
+			bars: {
+				show: true,
+				barWidth: 0.6
+			}
+		},
+	};
+
+	$(document).ready(function() {
+		var datagraph = $.plot("#datagraph", datagraph_data, datagraph_options);
+		var timingsgraph = $.plot("#timingsgraph", timingsgraph_data, timingsgraph_options);
+
+		var overview = $.plot("#overview", {}, {
 			legend: { show: false},
 			series: {
 				lines: {
@@ -65,26 +105,46 @@ const (
 			}
 		});
 
-		// now connect the two
-		$("#placeholder").bind("plotselected", function (event, ranges) {
+		// now connect the three
+		$("#datagraph").bind("plotselected", function (event, ranges) {
 
 			// do the zooming
-			$.each(plot.getXAxes(), function(_, axis) {
+			$.each(datagraph.getXAxes(), function(_, axis) {
 				var opts = axis.options;
 				opts.min = ranges.xaxis.from;
 				opts.max = ranges.xaxis.to;
 			});
-			plot.setupGrid();
-			plot.draw();
-			plot.clearSelection();
+			datagraph.setupGrid();
+			datagraph.draw();
+			datagraph.clearSelection();
 
 			// don't fire event on the overview to prevent eternal loop
 
 			overview.setSelection(ranges, true);
+			timingsgraph.setSelection(ranges, true);
+		});
+
+		$("#timingsgraph").bind("plotselected", function (event, ranges) {
+
+			// do the zooming
+			$.each(timingsgraph.getXAxes(), function(_, axis) {
+				var opts = axis.options;
+				opts.min = ranges.xaxis.from;
+				opts.max = ranges.xaxis.to;
+			});
+			timingsgraph.setupGrid();
+			timingsgraph.draw();
+			timingsgraph.clearSelection();
+
+			// don't fire event on the overview to prevent eternal loop
+
+			overview.setSelection(ranges, true);
+			datagraph.setSelection(ranges, true);
 		});
 
 		$("#overview").bind("plotselected", function (event, ranges) {
-			plot.setSelection(ranges);
+			datagraph.setSelection(ranges);
+			timingsgraph.setSelection(ranges);
 		});
 
 		// refresh data every second
@@ -92,7 +152,7 @@ const (
 
 		function pullAndRedraw() {
 			$.get(window.location.href + 'graph.json', function(graphData) {
-				var data = [
+				var datagraph_data = [
 					{ label: "gc.heapinuse", data: graphData.HeapUse },
 					{ label: "scvg.inuse", data: graphData.ScvgInuse },
 					{ label: "scvg.idle", data: graphData.ScvgIdle },
@@ -100,12 +160,22 @@ const (
 					{ label: "scvg.released", data: graphData.ScvgReleased },
 					{ label: "scvg.consumed", data: graphData.ScvgConsumed }
 				];
+				var timingsgraph_data = [
+					{ label: "STW sweep clock",    data: graphData.STWSclock },
+					{ label: "con mas clock",      data: graphData.MASclock },
+					{ label: "STW mark clock",     data: graphData.STWMclock },
+					{ label: "STW sweep cpu",      data: graphData.STWScpu },
+					{ label: "con mas assist cpu", data: graphData.MASAssistcpu },
+					{ label: "con mas bg cpu",     data: graphData.MASBGcpu },
+					{ label: "con mas idle cpu",   data: graphData.MASIdlecpu },
+					{ label: "STW mark cpu",       data: graphData.STWMcpu },
+				];
 
-				plot.setData(data);
-				plot.setupGrid();
-				plot.draw();
+				datagraph.setData(datagraph_data);
+				datagraph.setupGrid();
+				datagraph.draw();
 
-				overview.setData(data);
+				overview.setData(timingsgraph_data);
 				overview.setupGrid();
 				overview.draw();
 
@@ -124,8 +194,10 @@ const (
 #export {
 	float: right;
 }
+dt { float: left; font-weight:bold; width: 160px; }
+dd { margin-left: 160px; }
 
-.demo-container {
+.graph-container {
 	box-sizing: border-box;
 	width: 1200px;
 	height: 450px;
@@ -145,6 +217,27 @@ const (
 	-webkit-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
 }
 
+.legend-container {
+	box-sizing: border-box;
+	width: 1200px;
+	height: 450px;
+	padding: 2px 1px 1px 1px;
+	margin: 15px auto 30px auto;
+	border: 0px;
+	background: #fff;
+	background: linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -o-linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -ms-linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -moz-linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -webkit-linear-gradient(#f6f6f6 0, #fff 50px);
+	box-shadow: 0 3px 10px rgba(0,0,0,0.15);
+	-o-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+	-ms-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+	-moz-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+	-webkit-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+}
+
+
 .demo-placeholder {
 	width: 100%;
 	height: 100%;
@@ -160,11 +253,15 @@ const (
 </div>
 <div id="content">
 
-	<div class="demo-container">
-		<div id="placeholder" class="demo-placeholder"></div>
+	<div class="graph-container">
+		<div id="datagraph" class="demo-placeholder"></div>
 	</div>
 
-	<div class="demo-container" style="height:150px;">
+	<div class="graph-container">
+		<div id="timingsgraph" class="demo-placeholder"></div>
+	</div>
+
+	<div class="legend-container" style="height:60px;">
 		<div id="overview" class="demo-placeholder"></div>
 	</div>
 
@@ -173,13 +270,25 @@ const (
 </div>
 
 <pre><b>Legend</b>
+<dl>
 
-gc.heapinuse: heap in use after gc
-scvg.inuse: virtual memory considered in use by the scavenger
-scvg.idle: virtual memory considered unused by the scavenger
-scvg.sys: virtual memory requested from the operating system (should aproximate VSS)
-scvg.released: virtual memory returned to the operating system by the scavenger
-scvg.consumed: virtual memory in use (should roughly match process RSS)
+<dt>gc.heapinuse  </dt><dd> heap in use after gc</dd>
+<dt>scvg.inuse    </dt><dd> virtual memory considered in use by the scavenger</dd>
+<dt>scvg.idle     </dt><dd> virtual memory considered unused by the scavenger</dd>
+<dt>scvg.sys      </dt><dd> virtual memory requested from the operating system (should aproximate VSS)</dd>
+<dt>scvg.released </dt><dd> virtual memory returned to the operating system by the scavenger</dd>
+<dt>scvg.consumed </dt><dd> virtual memory in use (should roughly match process RSS)</dd>
+
+<dt>STW sweep clock   </dt><dd>stop-the-world sweep clock time</dd>
+<dt>con mas clock     </dt><dd>concurrent mark and scan clock time</dd>
+<dt>STW mark clock    </dt><dd>stop-the-world mark clock time</dd>
+<dt>STW sweep cpu     </dt><dd>stop-the-world sweep cpu time</dd>
+<dt>con mas assist cpu</dt><dd>concurrent mark and scan - assist cpu time (GC performed in line with allocation)</dd>
+<dt>con mas bg cpu    </dt><dd>concurrent mark and scan - background GC cpu time</dd>
+<dt>con mas idle cpu  </dt><dd>concurrent mark and scan - idle GC cpu time</dd>
+<dt>STW mark cpu      </dt><dd>stop-the-world mark cpu time</dd>
+</dl>
+
 </pre>
 </body>
 </html>

--- a/template.go
+++ b/template.go
@@ -39,10 +39,12 @@ const (
 		},
 	};
 
-	var timingsgraph_data = [
+	var clockgraph_data = [
 		{ label: "STW sweep clock", data: {{ .STWSclock }} },
 		{ label: "con mas clock", data: {{ .MASclock }} },
 		{ label: "STW mark clock", data: {{ .STWMclock }} },
+	];
+	var cpugraph_data = [
 		{ label: "STW sweep cpu", data: {{ .STWScpu }} },
 		{ label: "con mas assist cpu", data: {{ .MASAssistcpu }} },
 		{ label: "con mas bg cpu", data: {{ .MASBGcpu }} },
@@ -68,18 +70,17 @@ const (
 		series: {
 			stack: 0,
 			lines: {
-				show: false,
-			},
-			bars: {
 				show: true,
-				barWidth: 0.6
-			}
+				fill:true,
+				lineWidth: 0,
+			},
 		},
 	};
 
 	$(document).ready(function() {
 		var datagraph = $.plot("#datagraph", datagraph_data, datagraph_options);
-		var timingsgraph = $.plot("#timingsgraph", timingsgraph_data, timingsgraph_options);
+		var clockgraph = $.plot("#clockgraph", clockgraph_data, timingsgraph_options);
+		var cpugraph = $.plot("#cpugraph", cpugraph_data, timingsgraph_options);
 
 		var overview = $.plot("#overview", {}, {
 			legend: { show: false},
@@ -105,7 +106,7 @@ const (
 			}
 		});
 
-		// now connect the three
+		// now connect the four
 		$("#datagraph").bind("plotselected", function (event, ranges) {
 
 			// do the zooming
@@ -119,32 +120,53 @@ const (
 			datagraph.clearSelection();
 
 			// don't fire event on the overview to prevent eternal loop
-
 			overview.setSelection(ranges, true);
-			timingsgraph.setSelection(ranges, true);
+			clockgraph.setSelection(ranges, true);
+			cpugraph.setSelection(ranges, true);
 		});
 
-		$("#timingsgraph").bind("plotselected", function (event, ranges) {
+		$("#clockgraph").bind("plotselected", function (event, ranges) {
 
 			// do the zooming
-			$.each(timingsgraph.getXAxes(), function(_, axis) {
+			$.each(clockgraph.getXAxes(), function(_, axis) {
 				var opts = axis.options;
 				opts.min = ranges.xaxis.from;
 				opts.max = ranges.xaxis.to;
 			});
-			timingsgraph.setupGrid();
-			timingsgraph.draw();
-			timingsgraph.clearSelection();
+			clockgraph.setupGrid();
+			clockgraph.draw();
+			clockgraph.clearSelection();
 
 			// don't fire event on the overview to prevent eternal loop
 
 			overview.setSelection(ranges, true);
 			datagraph.setSelection(ranges, true);
+			cpugraph.setSelection(ranges, true);
+		});
+
+		$("#cpugraph").bind("plotselected", function (event, ranges) {
+
+			// do the zooming
+			$.each(cpugraph.getXAxes(), function(_, axis) {
+				var opts = axis.options;
+				opts.min = ranges.xaxis.from;
+				opts.max = ranges.xaxis.to;
+			});
+			cpugraph.setupGrid();
+			cpugraph.draw();
+			cpugraph.clearSelection();
+
+			// don't fire event on the overview to prevent eternal loop
+
+			overview.setSelection(ranges, true);
+			datagraph.setSelection(ranges, true);
+			clockraph.setSelection(ranges, true);
 		});
 
 		$("#overview").bind("plotselected", function (event, ranges) {
 			datagraph.setSelection(ranges);
-			timingsgraph.setSelection(ranges);
+			clockgraph.setSelection(ranges);
+			cpugraph.setSelection(ranges);
 		});
 
 		// refresh data every second
@@ -160,10 +182,12 @@ const (
 					{ label: "scvg.released", data: graphData.ScvgReleased },
 					{ label: "scvg.consumed", data: graphData.ScvgConsumed }
 				];
-				var timingsgraph_data = [
+				var clockgraph_data = [
 					{ label: "STW sweep clock",    data: graphData.STWSclock },
 					{ label: "con mas clock",      data: graphData.MASclock },
 					{ label: "STW mark clock",     data: graphData.STWMclock },
+				];
+				var cpugraph_data = [
 					{ label: "STW sweep cpu",      data: graphData.STWScpu },
 					{ label: "con mas assist cpu", data: graphData.MASAssistcpu },
 					{ label: "con mas bg cpu",     data: graphData.MASBGcpu },
@@ -175,7 +199,15 @@ const (
 				datagraph.setupGrid();
 				datagraph.draw();
 
-				overview.setData(timingsgraph_data);
+				clockgraph.setData(clockgraph_data);
+				clockgraph.setupGrid();
+				clockgraph.draw();
+
+				cpugraph.setData(cpugraph_data);
+				cpugraph.setupGrid();
+				cpugraph.draw();
+
+				overview.setData(datagraph_data);
 				overview.setupGrid();
 				overview.draw();
 
@@ -200,7 +232,27 @@ dd { margin-left: 160px; }
 .graph-container {
 	box-sizing: border-box;
 	width: 1200px;
-	height: 450px;
+	height: 340px;
+	padding: 20px 15px 15px 15px;
+	margin: 15px auto 30px auto;
+	border: 1px solid #ddd;
+	background: #fff;
+	background: linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -o-linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -ms-linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -moz-linear-gradient(#f6f6f6 0, #fff 50px);
+	background: -webkit-linear-gradient(#f6f6f6 0, #fff 50px);
+	box-shadow: 0 3px 10px rgba(0,0,0,0.15);
+	-o-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+	-ms-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+	-moz-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+	-webkit-box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+}
+
+.small-graph-container {
+	box-sizing: border-box;
+	width: 1200px;
+	height: 220px;
 	padding: 20px 15px 15px 15px;
 	margin: 15px auto 30px auto;
 	border: 1px solid #ddd;
@@ -257,8 +309,12 @@ dd { margin-left: 160px; }
 		<div id="datagraph" class="demo-placeholder"></div>
 	</div>
 
-	<div class="graph-container">
-		<div id="timingsgraph" class="demo-placeholder"></div>
+	<div class="small-graph-container">
+		<div id="clockgraph" class="demo-placeholder"></div>
+	</div>
+
+	<div class="small-graph-container">
+		<div id="cpugraph" class="demo-placeholder"></div>
 	</div>
 
 	<div class="legend-container" style="height:60px;">

--- a/tracedata.go
+++ b/tracedata.go
@@ -10,27 +10,35 @@ type scvgtrace struct {
 }
 
 type gctrace struct {
-	ElapsedTime float64 // in seconds
-	NumGC       int64
-	Nproc       int64
-	t1          int64
-	t2          int64
-	t3          int64
-	t4          int64
-	Heap0       int64 // heap size before, in megabytes
-	Heap1       int64 // heap size after, in megabytes
-	Obj         int64
-	NMalloc     int64
-	NFree       int64
-	NSpan       int64
-	NGoRoutines int64
-	NBGSweep    int64
-	NPauseSweep int64
-	NHandoff    int64
-	NHandoffCnt int64
-	NSteal      int64
-	NStealCnt   int64
-	NProcYield  int64
-	NOsYield    int64
-	NSleep      int64
+	ElapsedTime  float64 // in seconds
+	NumGC        int64
+	Nproc        int64
+	t1           int64
+	t2           int64
+	t3           int64
+	t4           int64
+	Heap0        int64 // heap size before, in megabytes
+	Heap1        int64 // heap size after, in megabytes
+	Obj          int64
+	NMalloc      int64
+	NFree        int64
+	NSpan        int64
+	NGoRoutines  int64
+	NBGSweep     int64
+	NPauseSweep  int64
+	NHandoff     int64
+	NHandoffCnt  int64
+	NSteal       int64
+	NStealCnt    int64
+	NProcYield   int64
+	NOsYield     int64
+	NSleep       int64
+	STWSclock    float64
+	MASclock     float64
+	STWMclock    float64
+	STWScpu      float64
+	MASAssistcpu float64
+	MASBGcpu     float64
+	MASIdlecpu   float64
+	STWMcpu      float64
 }


### PR DESCRIPTION
I wanted to get insights in the GC timings so I extended gcvis to also parse out the timing measurements and show them.
note: i just modified the regex for go 1.5, but only tested it with 1.6, not sure if these versions use an identical format?
screenshots (note: program instrumented had very few scavenger runs)
BEFORE:
![old](https://cloud.githubusercontent.com/assets/20774/13720524/34738522-e7af-11e5-9030-08b5f4fee4d8.png)
AFTER:
![new](https://cloud.githubusercontent.com/assets/20774/13720525/386e3884-e7af-11e5-91af-fff673fdf135.png)

