### PR TITLE
Fix break in main loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			break
+			os.Exit(0)
 		}
 	}
 


### PR DESCRIPTION
When the parser signals that it is done, the main loop wants to exit, but the break for the for loop was only breaking the select case and not the loop. 

Before this patch, if the input was closed (for example when we pipe into gcvis and the process on the left was done) gcvis would always go into the done case, just break the case and then continue to the next iteration of the loop, which would again choose the done case and continue like this forever, eating up a single CPU core (effectively busy looping).

Fix this by replacing the break with os.Exit(0).